### PR TITLE
Fix: Parsing error on partition_networks_list_from_dissimilarity()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: colSBM
 Title: Stochastic Block Model for Collection of Networks
-Version: 0.4.9
+Version: 0.4.10
 Authors@R: c(
     person("Saint-Clair", "Chabert-Liddell", , "academic@chabert-liddell.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-5604-7308")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# colSBM 0.4.10
+
+* @JulAgu fixed a bug that prevented unipartite collections to be splitted all the way to single networks.
+
 # colSBM 0.4.9
 
 * estimate_colBiSBM : fixing a bug that occurred when merging the different runs

--- a/R/estimatepopbm.R
+++ b/R/estimatepopbm.R
@@ -671,7 +671,9 @@ partition_networks_list_from_dissimilarity <- function(
   }
 
 
-  if (M >= 3L) {
+  if (M == 1L) {
+    cl <- 1L
+  } else if (M >= 3L) {
     # If there is more than 3 networks they are splitted using partition around
     # K-medioids
     cl <- cutree(hclust(as.dist(sqrt(dissimilarity_matrix)), method = method), k = nb_groups)

--- a/R/estimatepopbm.R
+++ b/R/estimatepopbm.R
@@ -658,7 +658,7 @@ partition_networks_list_from_dissimilarity <- function(
   nb_groups = 2L
 ) {
   # Sanity checks
-  check_networks_list(networks_list)
+  check_networks_list(networks_list, min_length = 1L)
   check_dissimilarity_matrix(dissimilarity_matrix)
   M <- length(networks_list)
 

--- a/R/estimatepopbm.R
+++ b/R/estimatepopbm.R
@@ -131,6 +131,10 @@ clusterize_unipartite_networks <- function(netlist,
     clustering_queue <- clustering_queue[-1]
 
     # If the collection contains only one network, add it to the final list
+    if (inherits(fit, "bmpop") && fit$best_fit$M == 1) {
+      list_model_binary <- append(list_model_binary, list(fit$best_fit))
+      next
+    }
     if (inherits(fit, "bisbmpop") && fit$best_fit$M == 1) {
       list_model_binary <- append(list_model_binary, list(fit$best_fit))
       next

--- a/tests/testthat/test-estimatepopbm.R
+++ b/tests/testthat/test-estimatepopbm.R
@@ -36,6 +36,42 @@ test_that("clusterize_unipartite_networks works with valid inputs", {
   expect_true(all(colnames(result$cluster_history) == names(result$cluster)))
 })
 
+test_that("clusterize_unipartite_networks can handle splitting apart two networks", {
+  fast_fit_opts <- list(max_vem_steps = 100L)
+  set.seed(0)
+  alpha1 <- matrix(c(0.8, 0.1, 0.2, 0.7), byrow = TRUE, nrow = 2)
+  alpha2 <- matrix(c(0.8, 0.5, 0.5, 0.2), byrow = TRUE, nrow = 2)
+  first_collection <- generate_unipartite_collection(
+    n = 12,
+    pi = c(0.5, 0.5),
+    alpha = alpha1,
+    M = 1
+  )
+  second_collection <- generate_unipartite_collection(
+    n = 12,
+    pi = c(0.5, 0.5),
+    alpha = alpha2,
+    M = 1
+  )
+  netlist <- append(first_collection, second_collection)
+
+  result2split <- clusterize_unipartite_networks(
+    netlist = netlist,
+    colsbm_model = "iid",
+    nb_run = 1L,
+    global_opts = list(nb_cores = 1L, backend = "no_mc", verbosity = 0L, Q_max = 3L),
+    fit_opts = fast_fit_opts,
+    verbose = FALSE,
+    temp_save_path = NULL
+  )
+
+  expect_type(result2split, "list")
+  expect_named(result2split, c("partition", "cluster", "elapsed_time", "cluster_history"))
+  expect_true(all(sapply(result2split$partition, inherits, "fitSimpleSBMPop")))
+  expect_length(result2split$cluster, length(netlist))
+  expect_true(all(colnames(result2split$cluster_history) == names(result2split$cluster)))
+})
+
 test_that("clusterize_unipartite_networks handles invalid colsbm_model", {
   netlist <- list(matrix(0, 10, 10), matrix(0, 10, 10))
 


### PR DESCRIPTION
The else branch (M == 2) was returning c(1L, 2L) for both M == 1… and M == 2, but when there's only 1 network you can't split it into 2 groups. The fix adds an explicit M == 1 case that returns cl <- 1L (a single group). I also made a minimal change on  check_networks_list() for avoiding the error rise. Finally I write a guardrail mirroring the "bipartite logic" for adding a network to the final list if the collection contains only one network.

Since I know absolutely nothing about your underlying statistical methodology, I simply made the logical changes necessary to get the code running. Feel free to thoroughly verify that I haven't broken the mathematical logic.